### PR TITLE
Add Sandbox Mode onto SendGridMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,61 @@ class ExampleNotification extends Notification
 
 💡 Unless you set it explicitly, the **From** address will be set to `config('mail.from.address')` and the **To** value will be what returns from `$notifiable->routeNotificationFor('mail');`
 
+## Sandbox Mode
+
+To enable sandbox mode you will need to
+
+1. Chain on the `enableSandboxMode(value)` to the `new SendGridMessage('template_id')`
+
+Example:
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Notifications\Notification;
+use NotificationChannels\SendGrid\SendGridChannel;
+
+class ExampleNotification extends Notification
+{
+    public function via($notifiable)
+    {
+        return [
+            SendGridChannel::class,
+            // And any other channels you want can go here...
+        ];
+    }
+
+    // ...
+
+    public function toSendGrid($notifiable)
+    {
+        return (new SendGridMessage('Your SendGrid template ID'))
+            /**
+             * optionally set the from address.
+             * by default this comes from config/mail.from
+             * ->from('no-reply@test.com', 'App name')
+             */
+            /**
+             * optionally set the recipient.
+             * by default it's $notifiable->email:
+             * ->to('hello@example.com', 'Mr. Smith')
+             */
+            
+            ->enableSandboxMode(true)
+            ->payload([
+                "template_var_1" => "template_value_1"
+            ]);
+	}
+}
+
+```
+
+`NotificationChannels\SendGrid\SendGridMessage` instance will enable sandbox mode.
+
+💡 You can pass through a config value into the `->enableSandboxMode(config('key'))`
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class ExampleNotification extends Notification
 
 To enable sandbox mode you will need to
 
-1. Chain on the `enableSandboxMode(value)` to the `new SendGridMessage('template_id')`
+1. Chain on the `enableSandboxMode(bool)` to the `new SendGridMessage('template_id')`
 
 Example:
 
@@ -149,10 +149,6 @@ class ExampleNotification extends Notification
 }
 
 ```
-
-`NotificationChannels\SendGrid\SendGridMessage` instance will enable sandbox mode.
-
-💡 You can pass through a config value into the `->enableSandboxMode(config('key'))`
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class ExampleNotification extends Notification
 
 To enable sandbox mode you will need to
 
-1. Chain on the `enableSandboxMode(bool)` to the `new SendGridMessage('template_id')`
+1. Chain on the `enableSandboxMode(true)` to the `new SendGridMessage('template_id')`
 
 Example:
 

--- a/src/SendGridMessage.php
+++ b/src/SendGridMessage.php
@@ -43,6 +43,11 @@ class SendGridMessage
     public $payload = [];
 
     /**
+     * The sandbox mode for SendGrid
+     */
+    public $sandbox_mode = false;
+
+    /**
      * Create a new SendGrid channel instance.
      *
      * @param  string  $templateId
@@ -110,10 +115,24 @@ class SendGridMessage
 
         $email->setTemplateId($this->templateId);
 
+        if($this->sandbox_mode){
+            $email->enableSandBoxMode();
+        }
+
         foreach ($this->payload as $key => $value) {
             $email->addDynamicTemplateData((string) $key, (string) $value);
         }
 
         return $email;
+    }
+
+    /**
+     * Set the "sandbox_mode".
+     */
+    public function enableSandboxMode($enabled): SendGridMessage
+    {
+        $this->sandbox_mode = $enabled;
+
+        return $this;
     }
 }

--- a/src/SendGridMessage.php
+++ b/src/SendGridMessage.php
@@ -44,6 +44,8 @@ class SendGridMessage
 
     /**
      * The sandbox mode for SendGrid
+     *
+     * @var bool
      */
     public $sandbox_mode = false;
 
@@ -128,8 +130,10 @@ class SendGridMessage
 
     /**
      * Set the "sandbox_mode".
+     * @param bool $enabled
+     * @return $this
      */
-    public function enableSandboxMode($enabled): SendGridMessage
+    public function enableSandboxMode($enabled)
     {
         $this->sandbox_mode = $enabled;
 

--- a/src/SendGridMessage.php
+++ b/src/SendGridMessage.php
@@ -130,6 +130,7 @@ class SendGridMessage
 
     /**
      * Set the "sandbox_mode".
+     *
      * @param bool $enabled
      * @return $this
      */

--- a/tests/SendGridChannelTest.php
+++ b/tests/SendGridChannelTest.php
@@ -56,6 +56,7 @@ class SendGridChannelTest extends TestCase
         $this->assertEquals($message->payload['baz'], 'foo2');
         $this->assertEquals($message->replyTo->getEmail(), 'replyto@example.com');
         $this->assertEquals($message->replyTo->getName(), 'Reply To');
+        $this->assertEquals($message->sandbox_mode, false);
 
         // TODO: Verify that the Mail instance passed contains all the info from above
         $sendgrid->shouldReceive('send')->once()->andReturn($response);

--- a/tests/SendGridChannelTest.php
+++ b/tests/SendGridChannelTest.php
@@ -63,4 +63,51 @@ class SendGridChannelTest extends TestCase
 
         $channel->send($notifiable, $notification);
     }
+
+    public function testEmailIsNotSentViaSendGridWithSandbox()
+    {
+        $notification = new class extends Notification {
+            public function toSendGrid($notifiable)
+            {
+                return (new SendGridMessage('sendgrid-template-id'))
+                    ->from('test@example.com', 'Example User')
+                    ->to('test+test1@example.com', 'Example User1')
+                    ->replyTo('replyto@example.com', 'Reply To')
+                    ->payload([
+                        'bar' => 'foo',
+                        'baz' => 'foo2',
+                    ])
+                    ->enableSandboxMode(true);
+            }
+        };
+
+        $notifiable = new class {
+            use Notifiable;
+        };
+
+        $channel = new SendGridChannel(
+            $sendgrid = Mockery::mock(new SendGrid('x'))
+        );
+
+        $response = Mockery::mock(Response::class);
+        $response->shouldReceive('statusCode')->andReturn(200);
+
+        $message = $notification->toSendGrid($notifiable);
+
+        $this->assertEquals($message->templateId, 'sendgrid-template-id');
+        $this->assertEquals($message->from->getEmail(), 'test@example.com');
+        $this->assertEquals($message->from->getName(), 'Example User');
+        $this->assertEquals($message->tos[0]->getEmail(), 'test+test1@example.com');
+        $this->assertEquals($message->tos[0]->getName(), 'Example User1');
+        $this->assertEquals($message->payload['bar'], 'foo');
+        $this->assertEquals($message->payload['baz'], 'foo2');
+        $this->assertEquals($message->replyTo->getEmail(), 'replyto@example.com');
+        $this->assertEquals($message->replyTo->getName(), 'Reply To');
+        $this->assertEquals($message->sandbox_mode, true);
+
+        // TODO: Verify that the Mail instance passed contains all the info from above
+        $sendgrid->shouldReceive('send')->once()->andReturn($response);
+
+        $channel->send($notifiable, $notification);
+    }
 }


### PR DESCRIPTION
This package served our needs perfectly but I noticed while using the package in my project, we were struggling to enable sandbox mode to ensure emails are not sent to the recipients. 

This PR exposes a new 'enableSandboxMode' function on the SendGridMessage class.

We think this could be a nice feature to include in the package as I think other developers can make use of it by chaining on a new function within the SendGridMessage which allows the user to have sandbox enabled.

The default behaviour of the package remains unchanged and the tests have been updated

```php
public function toSendGrid($notifiable): SendGridMessage
{
    return (new SendGridMessage(config('services.sendgrid.templates.default')))
        ->enableSandboxMode(config('services.sendgrid.sandbox_enabled'))
        ->payload([
            ...
        ]);
}
```