### PR TITLE
Allow cleaner implementation api of sandbox mode

### DIFF
--- a/src/SendGridMessage.php
+++ b/src/SendGridMessage.php
@@ -134,9 +134,10 @@ class SendGridMessage
      * without delivering the email to any of your recipients.
      *
      * @see https://docs.sendgrid.com/for-developers/sending-email/sandbox-mode
+     * @param bool $enabled
      * @return $this
      */
-    public function enableSandboxMode( $enabled = true)
+    public function enableSandboxMode($enabled = true)
     {
         $this->sandboxMode = $enabled;
 

--- a/src/SendGridMessage.php
+++ b/src/SendGridMessage.php
@@ -136,9 +136,9 @@ class SendGridMessage
      * @see https://docs.sendgrid.com/for-developers/sending-email/sandbox-mode
      * @return $this
      */
-    public function enableSandboxMode()
+    public function enableSandboxMode( $enabled = true)
     {
-        $this->sandboxMode = true;
+        $this->sandboxMode = $enabled;
 
         return $this;
     }


### PR DESCRIPTION
Thank you for merging in my previous request.

I would like to please request one last change which will allow a user to be able to pass through a value to the function to be able to toggle the sandbox with one variable change (eg: the env value).

This change will allow the following:
```php
public function toSendGrid($notifiable): SendGridMessage
  {
      return (new SendGridMessage(config('services.sendgrid.templates.default')))
          ->enableSandboxMode(config('services.sendgrid.sandbox_enabled'))
          ->payload([
              ...
          ]);
  }
```

Without the change this PR introduces, the user is forced to make use of a temporary variable as indicated below
```php
public function toSendGrid($notifiable): SendGridMessage
    {
        $sendGridMessage = (new SendGridMessage(config('services.sendgrid.templates.default')))
            ->payload([
                    ...
                ]);

        if (config('services.sendgrid.sandbox_enabled')) {
            return $sendGridMessage
                ->enableSandboxMode();
        }

        return $sendGridMessage;
    }
```

This change will not affect the current behaviour with the variable defaulting to true but gives the developer a slightly cleaner implementation for updating the value to enable or disable sandbox mode.