### PR TITLE
remove type casting to allow addDynamicTemplateData to accept arrays.

### DIFF
--- a/src/SendGridMessage.php
+++ b/src/SendGridMessage.php
@@ -122,7 +122,7 @@ class SendGridMessage
         }
 
         foreach ($this->payload as $key => $value) {
-            $email->addDynamicTemplateData((string) $key, (string) $value);
+            $email->addDynamicTemplateData((string) $key, $value);
         }
 
         return $email;


### PR DESCRIPTION
Hello,

I have a set of dynamic data that includes both strings and arrays. Here's a sample of that data:

```
array (
  'sender' => 
  array (
    'firstName' => 'John',
    'fullName' => 'John doe',
    'email' => 'john@example.com',
  ),
  'state' => 'Colorado',
  'residence' => 'Nonresident',
  'year' => 2022,
  'licenses' => 
  array (
    0 => 
    array (
      'name' => 'Stamp',
      'cost' => '$10.59',
    ),
    1 => 
    array (
      'name' => 'Annual License',
      'cost' => '$86.50',
    ),
  ),
) 
```

I'm not sure if there's a better way to handle this, but type casting $value as a string was causing an error with the 'licenses' key, an array. Once removed, the data passed successfully to SendGrid and populated the template as expected.