### PR TITLE
Support array returning from routeNotificationForMail

### DIFF
--- a/src/SendGridChannel.php
+++ b/src/SendGridChannel.php
@@ -6,7 +6,6 @@ use SendGrid;
 use Exception;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\SendGrid\Exceptions\CouldNotSendNotification;
-use SendGrid\Mail\To;
 
 class SendGridChannel
 {
@@ -30,7 +29,7 @@ class SendGridChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (!method_exists($notification, 'toSendGrid')) {
+        if (! method_exists($notification, 'toSendGrid')) {
             throw new Exception('You must implement toSendGrid in the notification class for SendGrid channel.');
         }
 
@@ -58,7 +57,7 @@ class SendGridChannel
             }
         }
 
-        if (!($message instanceof SendGridMessage)) {
+        if (! ($message instanceof SendGridMessage)) {
             throw new Exception('toSendGrid must return an instance of SendGridMessage.');
         }
 

--- a/tests/SendGridChannelTest.php
+++ b/tests/SendGridChannelTest.php
@@ -9,8 +9,8 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\SendGrid\SendGridChannel;
-use Illuminate\Notifications\Events\NotificationSent;
 use NotificationChannels\SendGrid\SendGridMessage;
+use Illuminate\Notifications\Events\NotificationSent;
 
 class SendGridChannelTest extends TestCase
 {
@@ -23,8 +23,7 @@ class SendGridChannelTest extends TestCase
     {
         Event::fake();
 
-        $notification = new class extends Notification
-        {
+        $notification = new class extends Notification {
             public function via()
             {
                 return [SendGridChannel::class];
@@ -43,8 +42,7 @@ class SendGridChannelTest extends TestCase
             }
         };
 
-        $notifiable = new class
-        {
+        $notifiable = new class {
             use Notifiable;
         };
 
@@ -92,8 +90,7 @@ class SendGridChannelTest extends TestCase
 
         $channel = new SendGridChannel($this->mockSendgrid());
 
-        $notification = new class extends Notification
-        {
+        $notification = new class extends Notification {
             public $sendgridMessage;
 
             public function via()
@@ -115,8 +112,7 @@ class SendGridChannelTest extends TestCase
             }
         };
 
-        $notifiable = new class
-        {
+        $notifiable = new class {
             use Notifiable;
 
             public function routeNotificationForMail()
@@ -131,14 +127,13 @@ class SendGridChannelTest extends TestCase
 
         // Let's also support returning an array (email => name)
         // https://laravel.com/docs/10.x/notifications#customizing-the-recipient
-        $notifiableWithEmailAndName = new class
-        {
+        $notifiableWithEmailAndName = new class {
             use Notifiable;
 
             public function routeNotificationForMail()
             {
                 return [
-                    'john@example.com' => 'John Doe'
+                    'john@example.com' => 'John Doe',
                 ];
             }
         };

--- a/tests/SendGridChannelTest.php
+++ b/tests/SendGridChannelTest.php
@@ -47,13 +47,10 @@ class SendGridChannelTest extends TestCase
         };
 
         $channel = new SendGridChannel(
-            $sendgrid = Mockery::mock(new SendGrid('x'))
+            $this->mockSendgrid()
         );
 
         $this->app->instance(SendGridChannel::class, $channel);
-
-        $response = Mockery::mock(Response::class);
-        $response->shouldReceive('statusCode')->andReturn(200);
 
         $message = $notification->toSendGrid($notifiable);
 
@@ -67,9 +64,6 @@ class SendGridChannelTest extends TestCase
         $this->assertEquals($message->replyTo->getEmail(), 'replyto@example.com');
         $this->assertEquals($message->replyTo->getName(), 'Reply To');
         $this->assertEquals($message->sandboxMode, false);
-
-        // TODO: Verify that the Mail instance passed contains all the info from above
-        $sendgrid->shouldReceive('send')->once()->andReturn($response);
 
         $notifiable->notify($notification);
 


### PR DESCRIPTION
`routeNotificationForMail` can also return an array, where the array key is the email address and the value is the name.

This PR introduces support for this usage, and adds tests for it.

https://laravel.com/docs/10.x/notifications#customizing-the-recipient

Also related: #18

