### PR TITLE
add $notification as param to routeNotificationFor

### DIFF
--- a/src/SendGridChannel.php
+++ b/src/SendGridChannel.php
@@ -46,7 +46,7 @@ class SendGridChannel
         }
 
         if (empty($message->tos)) {
-            $to = $notifiable->routeNotificationFor('mail');
+            $to = $notifiable->routeNotificationFor('mail', $notification);
 
             // Handle the case where routeNotificationForMail returns an array (email => name)
             if (is_array($to)) {

--- a/tests/SendGridChannelTest.php
+++ b/tests/SendGridChannelTest.php
@@ -109,7 +109,7 @@ class SendGridChannelTest extends TestCase
         $notifiable = new class {
             use Notifiable;
 
-            public function routeNotificationForMail()
+            public function routeNotificationForMail($notification)
             {
                 return 'john@example.com';
             }
@@ -124,7 +124,7 @@ class SendGridChannelTest extends TestCase
         $notifiableWithEmailAndName = new class {
             use Notifiable;
 
-            public function routeNotificationForMail()
+            public function routeNotificationForMail($notification)
             {
                 return [
                     'john@example.com' => 'John Doe',


### PR DESCRIPTION
the notifiable routeNotificationFor method accepts the notification as the second param, but the send grid channel is not using it.