### PR TITLE
Multiple tos

### DIFF
--- a/src/SendGridChannel.php
+++ b/src/SendGridChannel.php
@@ -50,8 +50,9 @@ class SendGridChannel
 
             // Handle the case where routeNotificationForMail returns an array (email => name)
             if (is_array($to)) {
-                reset($to);
-                $message->to(key($to), current($to));
+                foreach ($to as $email => $name) {
+                    $message->to($email, $name);
+                }
             } else {
                 $message->to($to);
             }

--- a/tests/SendGridChannelTest.php
+++ b/tests/SendGridChannelTest.php
@@ -137,6 +137,27 @@ class SendGridChannelTest extends TestCase
 
         $this->assertEquals($message->tos[0]->getEmail(), 'john@example.com');
         $this->assertEquals($message->tos[0]->getName(), 'John Doe');
+
+        //Also support multiple recipients
+        $notifiableWithEmailAndName = new class {
+            use Notifiable;
+
+            public function routeNotificationForMail($notification)
+            {
+                return [
+                    'john@example.com' => 'John Doe',
+                    'jane@example.com' => 'Jane Doe',
+                ];
+            }
+        };
+
+        $channel->send($notifiableWithEmailAndName, $notification);
+        $message = $notification->sendgridMessage;
+
+        $this->assertEquals($message->tos[0]->getEmail(), 'john@example.com');
+        $this->assertEquals($message->tos[0]->getName(), 'John Doe');
+        $this->assertEquals($message->tos[1]->getEmail(), 'jane@example.com');
+        $this->assertEquals($message->tos[1]->getName(), 'Jane Doe');
     }
 
     private function mockSendgrid($statusCode = 200)


### PR DESCRIPTION
Adds the ability to use multiple to addresses.

At present:

```
routeNotificationForMail(Notification $notification)
{
  return [
    'john@example.com' => 'John Doe',
    'jane@example.com' => 'Jane Doe',
  ];
}
```

Only sends an email to john@example.com

The PR changes this and would send to both john@example.com and jane@example.com. It is backwards compatible with single recipients.
